### PR TITLE
3주차 과제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,12 @@ repositories {
 }
 
 dependencies {
+    // spring web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/src/main/java/org/sopt/controller/Authorization/AuthController.java
+++ b/src/main/java/org/sopt/controller/Authorization/AuthController.java
@@ -1,0 +1,91 @@
+package org.sopt.controller.Authorization;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.sopt.domain.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+@RestController
+public class AuthController {
+
+	@GetMapping("/login")
+	public ResponseEntity<String> login(HttpServletRequest request){
+		String authHeader = request.getHeader("Authorization");
+		if(authHeader == null || !authHeader.startsWith("Basic ")){
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("헤더가 이상합니다.");
+		}
+
+		String decodedString = authHeader.substring("Basic ".length());
+		byte[] decodedByte = Base64.getDecoder().decode(decodedString);
+		String credential = new String(decodedByte, StandardCharsets.UTF_8);
+
+		String[] parts = credential.split(":");
+		String userName = parts[0];
+		String password = parts[1];
+
+		if(userName.equals("soptUser") && password.equals("sopt1234")){
+			return ResponseEntity.ok("인증 성공");
+		}else{
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 실패");
+		}
+
+	}
+
+	@GetMapping("/set-cookie")
+	public ResponseEntity<String> setCookie(HttpServletRequest request, HttpServletResponse response){
+		String username = "userSopt";
+		String password = "sopt1234";
+
+		Cookie userNameCookie = new Cookie("userId",username);
+		Cookie passwordCookie = new Cookie("password",password);
+
+		//쿠키의 허용범위를 지정
+		userNameCookie.setPath("/");
+		passwordCookie.setPath("/");
+
+		//쿠키는 따로따로 구워서 response를 보내야 하는 것이다.
+		response.addCookie(userNameCookie);
+		response.addCookie(passwordCookie);
+
+		return ResponseEntity.ok("쿠키를 잘 구웠습니다.");
+	}
+
+	@GetMapping("/get-cookie")
+	public ResponseEntity<String> getCookie(
+		@CookieValue("userId") String userId,
+		@CookieValue("password") String password
+	){
+		return ResponseEntity.ok("받은 쿠키" + "유저 아이디 : " + userId + "유저 비밀번호 : " + password);
+	}
+
+
+	@PostMapping("/login")
+	public ResponseEntity<String> login2(HttpServletRequest request){
+
+		String userId = "userSopt";
+		String password = "sopt1234";
+
+		if(userId.equals("userSopt") && password.equals("sopt1234")){
+			HttpSession session = request.getSession(true);
+			session.setAttribute("user",new User("soptUser","메일"));
+
+			return ResponseEntity.ok("세션 저장 완료.");
+		}
+		throw new RuntimeException("");
+	}
+
+
+}
+
+

--- a/src/main/java/org/sopt/controller/Post/PostController.java
+++ b/src/main/java/org/sopt/controller/Post/PostController.java
@@ -1,19 +1,13 @@
-package org.sopt.controller;
+package org.sopt.controller.Post;
 
 
 
-import org.sopt.dto.PostDTO;
 import org.sopt.dto.PostRequest;
 import org.sopt.dto.PostUpdateDTO;
-import org.sopt.dto.ResponseDTO;
-import org.sopt.global.CheckTime;
-import org.sopt.global.exception.TImeLimitException;
 import org.sopt.global.response.ResponseCode;
-import org.sopt.service.PostService;
+import org.sopt.service.Post.PostService;
 import org.sopt.service.validator.PostValidator;
-import org.sopt.utils.EmojiUtil;
 import org.sopt.utils.ResponseUtil;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +15,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,12 +31,14 @@ public class PostController {
 	}
 
 	@PostMapping("")
-	public ResponseEntity<?> createPost(@RequestBody final PostRequest postRequest) {
+	public ResponseEntity<?> createPost(
+		@RequestHeader final Long userId,
+		@RequestBody final PostRequest postRequest) {
 		PostValidator.validateTitle(postRequest);
 		// if(!CheckTime.checkTime()){
 		// 	throw new TImeLimitException();
 		// }
-		return ResponseUtil.success(ResponseCode.POST_CREATED,postService.createPost(postRequest));
+		return ResponseUtil.success(ResponseCode.POST_CREATED,postService.createPost(userId,postRequest));
 	}
 
 
@@ -56,15 +53,20 @@ public class PostController {
 	}
 
 	@PatchMapping("/{contentId}")
-	public ResponseEntity<?> updatePostTitle(@PathVariable("contentId") final Long id, @RequestBody final PostRequest postRequest) {
+	public ResponseEntity<?> updatePostTitle(
+		@RequestHeader  final Long userId,
+		@PathVariable("contentId") final Long id,
+		@RequestBody final PostRequest postRequest) {
 		PostValidator.validateTitle(postRequest);
-		return ResponseUtil.success(ResponseCode.POST_UPDATED,postService.updatePostById(new PostUpdateDTO(id,postRequest)));
+		return ResponseUtil.success(ResponseCode.POST_UPDATED,postService.updatePostById(userId,new PostUpdateDTO(id,postRequest)));
 
 	}
 
 	@DeleteMapping("/{contentId}")
-	public ResponseEntity<?> deletePostById(@PathVariable("contentId") Long id) {
-		postService.deletePostById(id);
+	public ResponseEntity<?> deletePostById(
+		@RequestHeader final Long userId,
+		@PathVariable("contentId") final Long id) {
+		postService.deletePostById(userId,id);
 		return ResponseUtil.success(ResponseCode.POST_DELETED,null);
 	}
 

--- a/src/main/java/org/sopt/controller/Post/PostController.java
+++ b/src/main/java/org/sopt/controller/Post/PostController.java
@@ -26,6 +26,8 @@ public class PostController {
 
 	private final PostService postService;
 
+
+
 	public PostController(PostService postService) {
 		this.postService = postService;
 	}

--- a/src/main/java/org/sopt/controller/User/UserController.java
+++ b/src/main/java/org/sopt/controller/User/UserController.java
@@ -1,0 +1,30 @@
+package org.sopt.controller.User;
+
+import org.sopt.dto.UserRequest;
+import org.sopt.global.exception.NoNameException;
+import org.sopt.global.response.ResponseCode;
+import org.sopt.service.User.UserService;
+import org.sopt.service.validator.UserValidator;
+import org.sopt.utils.ResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+	private final UserService userService;
+
+	public UserController(UserService userService){
+		this.userService = userService;
+	}
+
+	@PostMapping
+	public ResponseEntity<?> createUser(@RequestBody UserRequest userRequest){
+		UserValidator.checkUser(userRequest);
+		return ResponseUtil.success(ResponseCode.USER_CREATED,userService.createUser(userRequest));
+	}
+}

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,5 +1,6 @@
 package org.sopt.domain;
 
+import org.sopt.global.BaseTtime;
 import org.springframework.lang.NonNull;
 
 import jakarta.annotation.Nonnull;
@@ -12,7 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class Post {
+public class Post extends BaseTtime {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -36,20 +37,32 @@ public class Post {
 		this.content = content;
 	}
 
-	public Post(String title){
+	public Post(String title,String content,User user){
 		this.title = title;
+		this.content = content;
+		this.user = user;
 	}
 
 	public Long getId() {
 		return id;
 	}
 
+	public User getUser() {
+		return user;
+	}
+
+	public String getContent() {
+		return content;
+	}
 
 	public String getTitle() {
 		return this.title;
 	}
 
-	public void changeTitle(String newTitle){
+	public void changeTitleAndContent(String newTitle,String newContent){
 		this.title = newTitle;
+		this.content = newContent;
 	}
+
+
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,28 +1,49 @@
 package org.sopt.domain;
 
+import org.springframework.lang.NonNull;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class Post {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(nullable = false)
 	private String title;
 
-	public Post() {
+	@Column(nullable = false)
+	private String content;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	protected Post() {
 
 	}
 
-	public Post(String title) {
+	public Post(String title,String content) {
+		this.title = title;
+		this.content = content;
+	}
+
+	public Post(String title){
 		this.title = title;
 	}
 
 	public Long getId() {
 		return id;
 	}
+
 
 	public String getTitle() {
 		return this.title;

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -1,0 +1,37 @@
+package org.sopt.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+@Entity
+public class User {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	private String email;
+
+	@OneToMany(mappedBy = "user")
+	private List<Post> contents = new ArrayList<>();
+
+
+	public User(){
+
+	}
+
+	public User(Long id, String name, String email) {
+		this.id = id;
+		this.name = name;
+		this.email = email;
+	}
+}

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -28,10 +28,18 @@ public class User {
 	public User(){
 
 	}
+	public User(String name, String email){
+		this.name = name;
+		this.email = email;
+	}
 
 	public User(Long id, String name, String email) {
 		this.id = id;
 		this.name = name;
 		this.email = email;
+	}
+
+	public String getName() {
+		return name;
 	}
 }

--- a/src/main/java/org/sopt/dto/PostDTO.java
+++ b/src/main/java/org/sopt/dto/PostDTO.java
@@ -1,4 +1,4 @@
 package org.sopt.dto;
 
-public record PostDTO (Long contentId, String title) {
+public record PostDTO (String title, String content, String userName) {
 }

--- a/src/main/java/org/sopt/dto/PostListDTO.java
+++ b/src/main/java/org/sopt/dto/PostListDTO.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.sopt.domain.Post;
-
+import org.sopt.domain.User;
 
 public class PostListDTO {
 	private  final List<Content> contentList;
@@ -13,7 +13,7 @@ public class PostListDTO {
 	public PostListDTO(List<Post> list){
 		List<Content> contentList = new ArrayList<>();
 		for(Post post : list){
-			contentList.add(new Content(post.getId(), post.getTitle()));
+			contentList.add(new Content(post.getUser(), post.getTitle()));
 		}
 		this.contentList =contentList;
 	}
@@ -23,16 +23,16 @@ public class PostListDTO {
 	}
 
 	private class Content{
-		private Long contentId;
+		private String userName;
 		private String title;
 
-		public Content(Long contentId, String title){
-			this.contentId = contentId;
+		public Content(User user , String title){
+			this.userName = user.getName();
 			this.title = title;
 		}
 
-		public Long getContentId() {
-			return contentId;
+		public String getUserName(){
+			return userName;
 		}
 
 		public String getTitle() {

--- a/src/main/java/org/sopt/dto/PostRequest.java
+++ b/src/main/java/org/sopt/dto/PostRequest.java
@@ -1,5 +1,5 @@
 package org.sopt.dto;
 
 
-public record PostRequest(String title) {
+public record PostRequest(String title, String content) {
 }

--- a/src/main/java/org/sopt/dto/UserRequest.java
+++ b/src/main/java/org/sopt/dto/UserRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.dto;
+
+public record UserRequest (String name, String email){
+}

--- a/src/main/java/org/sopt/global/BaseTtime.java
+++ b/src/main/java/org/sopt/global/BaseTtime.java
@@ -1,0 +1,23 @@
+package org.sopt.global;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTtime {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/sopt/global/config/JpaConfig.java
+++ b/src/main/java/org/sopt/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package org.sopt.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/org/sopt/global/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/global/exception/ErrorCode.java
@@ -8,7 +8,11 @@ public enum ErrorCode {
 	DUPLICATE_TITLE(HttpStatus.BAD_REQUEST,"중복된 제목입니다."),
 	NO_TITLE(HttpStatus.BAD_REQUEST,"제목이 비어있습니다."),
 	LONG_TITLE(HttpStatus.BAD_REQUEST,"제목의 최대 길이는 30자 입니다."),
-	NO_LIST(HttpStatus.BAD_REQUEST,"게시글이 존재하지 않습니다.");
+	NO_LIST(HttpStatus.BAD_REQUEST,"게시글이 존재하지 않습니다."),
+	NO_NAME(HttpStatus.BAD_REQUEST,"유저의 이름이 존재하지 않습니다."),
+	LONG_POST(HttpStatus.BAD_REQUEST,"게시물의 내용은 1000자 이내입니다."),
+	LONG_NAME(HttpStatus.BAD_REQUEST,"유저의 이름은 10자 이내입니다."),
+	NO_USER(HttpStatus.BAD_REQUEST,"사용자를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/org/sopt/global/exception/NoNameException.java
+++ b/src/main/java/org/sopt/global/exception/NoNameException.java
@@ -1,0 +1,7 @@
+package org.sopt.global.exception;
+
+public class NoNameException extends CustomException{
+	public NoNameException(){
+		super(ErrorCode.NO_NAME);
+	}
+}

--- a/src/main/java/org/sopt/global/response/ResponseCode.java
+++ b/src/main/java/org/sopt/global/response/ResponseCode.java
@@ -6,7 +6,9 @@ public enum ResponseCode {
 	POST_DELETED(200,"게시글이 삭제되었습니다."),
 	POST_DETAIL(200, "게시글 상세 조회"),
 	POST_ALL(200, "전체 게시글이 조회되었습니다."),
-	POST_KEY_SEARCH(200,"키워드로 게시글 검색 성공");
+	POST_KEY_SEARCH(200,"키워드로 게시글 검색 성공"),
+	USER_CREATED(201,"회원가입이 완료되었습니다.");
+
 
 	private final int status;
 	private final String message;

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post,Long> {
+
+	List<Post> findAllByOrderByCreatedAtDesc();
 	Boolean existsByTitle(String title);
 	List<Post> findAllByTitleContaining(String keyword);
 }

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.repository;
+
+import org.sopt.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+}

--- a/src/main/java/org/sopt/service/User/UserService.java
+++ b/src/main/java/org/sopt/service/User/UserService.java
@@ -1,0 +1,23 @@
+package org.sopt.service.User;
+
+import org.sopt.domain.User;
+import org.sopt.dto.UserRequest;
+import org.sopt.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository){
+		this.userRepository = userRepository;
+	}
+	@Transactional
+	public User createUser(UserRequest userRequest){
+		User user = new User(userRequest.name(),userRequest.email());
+		return userRepository.save(user);
+	}
+
+}

--- a/src/main/java/org/sopt/service/validator/PostValidator.java
+++ b/src/main/java/org/sopt/service/validator/PostValidator.java
@@ -1,6 +1,8 @@
 package org.sopt.service.validator;
 
 import org.sopt.dto.PostRequest;
+import org.sopt.global.exception.CustomException;
+import org.sopt.global.exception.ErrorCode;
 import org.sopt.global.exception.InvalidLongTitleException;
 import org.sopt.global.exception.InvalidNoTitleException;
 import org.sopt.utils.EmojiUtil;
@@ -14,6 +16,10 @@ public class PostValidator {
 		}
 		if ( EmojiUtil.getEmojiLength(title) > 30) {
 			throw new InvalidLongTitleException();
+		}
+
+		if(postRequest.content().length() > 1000){
+			throw new CustomException(ErrorCode.LONG_POST);
 		}
 	}
 }

--- a/src/main/java/org/sopt/service/validator/UserValidator.java
+++ b/src/main/java/org/sopt/service/validator/UserValidator.java
@@ -1,0 +1,19 @@
+package org.sopt.service.validator;
+
+import org.sopt.dto.UserRequest;
+import org.sopt.global.exception.CustomException;
+import org.sopt.global.exception.ErrorCode;
+import org.sopt.global.exception.NoNameException;
+
+public class UserValidator {
+
+	public static void checkUser(UserRequest userRequest){
+		String name = userRequest.name();
+		if(name.isEmpty()){
+			throw new NoNameException();
+		}
+		if(name.length() > 10){
+			throw new CustomException(ErrorCode.LONG_NAME);
+		}
+	}
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- #9 

## 📝 요약(Summary)

기존의 게시판에서 User를 추가해서 User와 Post의 연관관계를 이용할 수 있게끔 수정하였습니다.
또한 H2에서 mysql로 데이터베이스를 변경하였습니다.

혼자 힘으로 이것저것 고민하면서 코드를 작성하다 보니 온전힌 구조를 이해할 수 있어서 좋았습니다!!
항상 과제를 하는게 너무 즐겁습니다!


## TODO ✔️

### 필수과제
- [x] todo : 서비스에 유저를 추가해주세요.
- [x] todo : 게시글은 기본적으로 제목과 내용을 가지고 있으면 좋겠어요. 
- [x] todo : 회원가입 기능을 추가해주세요.
- [x] todo : 다음과 같은 API를 기본적으로 만들어주세요.


### 선택과제
- [x] todo : 다음과 같은 제약 조건을 추가해주세요.
    - 게시글의 제목은 30자를 넘지 않게 해주세요.
    - 게시글의 내용은 1000자를 넘지 않게 해주세요.
    - 유저의 이름(닉네임)은 10자를 넘지 않게 해주세요. 

- [x] todo : 다음과 같은 제약 조건을 추가해주세요.
    - 게시글의 제목은 중복되지 않게 해주세요.
    - 전체 게시글 목록에서 같은 제목을 가진 게시글이 없어야 합니다.


- [ ] todo : 검색 기능을 추가해주세요. 

- [ ] todo : 게시글에 태그를 지정할 수 있으면 좋겠어요.

### **🔎 키워드 과제**

<details>
<summary>✅ ERD는 무엇이고, 어떻게 작성하나요? (ERD Cloud 같은 ERD 작성 툴 사용해보기)</summary>
ERD는 Entitiy Relationship Diagram으로 관계형 데이터베이스에서 테이블간의 관계를 작성할 때 사용하는 것입니다.
최근에는 까마귀 발 표기법을 사용하여, ERD를 작성합니다. ERD Cloud를 통해 ERD를 작성해보았었는데, 이때 가장 고민했던 부분이 식별자 관계와 비식별자 관계였습니다. 이는 추후에 공부하여 식별자 관계는 외래 식별자를 주 식별자로 사용하는 것이고 비식별자 관계는 외래 식별자를 주 식별자로 사용하지 않는 것입니다. 

![스크린샷 2025-05-02 오후 8 18 17](https://github.com/user-attachments/assets/95adf3d1-9426-479c-98e2-019fb026a6dc)
위의 사진과 같은 방식으로 관계를 표현하여, 협업을 진행하거나 개발을 할 때 데이터베이스가 어떠한 관계를 맺고 있는지를 한 눈에 알아볼 수 있기 위해서 사용하는 것이라고 생각합니다.

</details>

<details>
<summary>✅ 게시글을 100개 작성한 유저가 회원 탈퇴를 해본다고 할게요. 남는 게시글은 어떻게 처리해야 될까요 ?</summary>

- `@ManyToOne`, `@OneToMany` 어노테이션에 대해 공부해보기
예를들어 ManyToOne은 주로 User가 쓴 게시글에 달리게 됩니다. 이를 통해서 User와 게시글을 연관관계를 맵핑할 수 있는 것입니다.
반대로 OneToMany는 유저 테이블에 주로 사용됩니다. 하나의 유저에 여러 개의 게시글이 있을 수 있기 때문입니다.
이러한 연관관계 맵핑에서 단방향과 양방향이 존재합니다.
단방향 맵핑은 한 쪽 엔티티에서만 다른 엔티티를 참조하는 구조로, 예를 들어 Post → User만 참조하고 User에서는 Post를 모를 때를 말합니다. 반대로 양방향 맵핑은 서로 알고 있는 상황을 의미합니다.


- `@OneToMany` 의 `cascade` 옵션과 `fetch` 옵션 공부하기
cascade 옵션의 경우 부모의 작업을 자식에게 물려주는 형태를 의미합니다.
fetch는 연관 엔티티를 언제 로딩할지를 정하는 옵션입니다.
두 가지 타입:
FetchType.EAGER (즉시 로딩): 엔티티 조회 시 연관된 자식들도 즉시 함께 로딩
FetchType.LAZY (지연 로딩): 연관된 자식은 필요할 때만 SQL 쿼리로 별도 로딩
이 존재합니다.
이를 통해 엔티티 조회할 때 자원을 다루는데 더 효율적으로 쓸 수 있습니다.


결론은 위의 상황에서는 남은 게시글은 삭제하는 것이 맞다고 생각합니다. 해당 유저가 탈퇴를 하였다는 것은 해상 게시글 사이트에서 더 이상 글을 작성하거나, 글을 공유하고 싶다는 의미를 갖고 있다고 생각해서 삭제해야 한다고 생각합니다. 그리고 이때 필요한 것이 cascade 옵션이라고생각합니다. 해당 옵션을 통해서 User를 삭제함과 동시에 user_id라는 외래키를 가진 테이블의 데이터까지 삭제하는 것이기 때문입니다.
</details>

## 💬 공유사항
- 다른 분들이 에러처리를 어떻게 진행하셨는지 궁금합니다 !!
- 또한 저는 글을 수정, 삭제할 때도 글을 작성한 유저가 맞는지 확인하는 로직을 추가하였는데, 다른 분들은 어떻게 했는지 궁금합니다.

Closes #9 

